### PR TITLE
Changed OptimizerType from Enum to IntEnum.

### DIFF
--- a/utils/hyperparameter_tuner.py
+++ b/utils/hyperparameter_tuner.py
@@ -89,7 +89,9 @@ class HyperparameterTuner:
             ranges = [(chunk[0], chunk[-1]) for chunk in chunks]
             ranges = reversed(ranges)
 
-            intermediate_dims = [trial.suggest_int(name=f"intermediate_dim_{i}", low=low, high=high) for i, (low, high)
+            # Cast from np.int to int allows to become JSON serializable.
+            intermediate_dims = [trial.suggest_int(name=f"intermediate_dim_{i}", low=int(low), high=int(high)) for
+                                 i, (low, high)
                                  in enumerate(ranges)]
 
             print(intermediate_dims)

--- a/utils/hyperparameter_tuner.py
+++ b/utils/hyperparameter_tuner.py
@@ -89,7 +89,8 @@ class HyperparameterTuner:
             ranges = [(chunk[0], chunk[-1]) for chunk in chunks]
             ranges = reversed(ranges)
 
-            intermediate_dims = [trial.suggest_int(name=f"intermediate_dim_{i}", low=low, high=high) for i, (low, high)
+            intermediate_dims = [trial.suggest_int(name=f"intermediate_dim_{i}", low=int(low), high=int(high)) for
+                                 i, (low, high)
                                  in enumerate(ranges)]
 
             print(intermediate_dims)

--- a/utils/optimizer.py
+++ b/utils/optimizer.py
@@ -1,10 +1,13 @@
-from enum import Enum
+from enum import IntEnum
 
 from tensorflow.keras.optimizers import Optimizer, Adadelta, Adagrad, Adam, Adamax, Ftrl, SGD, Nadam, RMSprop
 
 
-class OptimizerType(Enum):
+class OptimizerType(IntEnum):
     """ Enum class of various optimizer types.
+
+    This class must be IntEnum to be JSON serializable. This feature is important because, when Optuna's study is
+    saved in a relational DB, all objects must be JSON serializable.
     """
 
     SGD = 0

--- a/utils/optimizer.py
+++ b/utils/optimizer.py
@@ -1,9 +1,9 @@
-from enum import Enum
+from enum import IntEnum
 
 from tensorflow.keras.optimizers import Optimizer, Adadelta, Adagrad, Adam, Adamax, Ftrl, SGD, Nadam, RMSprop
 
 
-class OptimizerType(Enum):
+class OptimizerType(IntEnum):
     """ Enum class of various optimizer types.
     """
 


### PR DESCRIPTION
The reason for this change is that RDB (MySQL in our case) requires that objects which Optuna chooses to be a hyperparameters must be JSON serializable. Enum is not JSON serializable but IntEnum is.

Also numpy types are not JSON serializable. Casted numpy.int to Python int.